### PR TITLE
Adds return type declaration to methods

### DIFF
--- a/src/NodeVisitors/StackNodeVisitor.php
+++ b/src/NodeVisitors/StackNodeVisitor.php
@@ -45,7 +45,7 @@ final class StackNodeVisitor implements NodeVisitorInterface
     /**
      * @inheritDoc
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -10;
     }

--- a/src/Nodes/BodyNode.php
+++ b/src/Nodes/BodyNode.php
@@ -32,7 +32,7 @@ final class BodyNode extends Node
      *
      * @param Compiler $compiler
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $extension = TwigStackExtension::class;
 

--- a/src/Nodes/PrependNode.php
+++ b/src/Nodes/PrependNode.php
@@ -38,7 +38,7 @@ final class PrependNode extends Node
      *
      * @param Compiler $compiler
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $extension = TwigStackExtension::class;
         $stackName = $this->getAttribute('name');

--- a/src/Nodes/PushNode.php
+++ b/src/Nodes/PushNode.php
@@ -38,7 +38,7 @@ final class PushNode extends Node
      *
      * @param Compiler $compiler
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $extension = TwigStackExtension::class;
         $stackName = $this->getAttribute('name');

--- a/src/Nodes/StackNode.php
+++ b/src/Nodes/StackNode.php
@@ -32,7 +32,7 @@ final class StackNode extends Node
      *
      * @param Compiler $compiler
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         /** @var $extension TwigStackExtension */
         $extension = $compiler->getEnvironment()->getExtension(TwigStackExtension::class);

--- a/src/TokenParsers/PrependTokenParser.php
+++ b/src/TokenParsers/PrependTokenParser.php
@@ -20,7 +20,7 @@ final class PrependTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function parse(Token $token)
+    public function parse(Token $token): PrependNode
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
@@ -57,7 +57,7 @@ final class PrependTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function getTag()
+    public function getTag(): string
     {
         return 'prepend';
     }

--- a/src/TokenParsers/PushTokenParser.php
+++ b/src/TokenParsers/PushTokenParser.php
@@ -20,7 +20,7 @@ final class PushTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function parse(Token $token)
+    public function parse(Token $token): PushNode
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
@@ -57,7 +57,7 @@ final class PushTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function getTag()
+    public function getTag(): string
     {
         return 'push';
     }

--- a/src/TokenParsers/StackTokenParser.php
+++ b/src/TokenParsers/StackTokenParser.php
@@ -17,7 +17,7 @@ final class StackTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function parse(Token $token)
+    public function parse(Token $token): StackNode
     {
         $stream = $this->parser->getStream();
 
@@ -30,7 +30,7 @@ final class StackTokenParser extends AbstractTokenParser
     /**
      * @inheritDoc
      */
-    public function getTag()
+    public function getTag(): string
     {
         return 'stack';
     }

--- a/src/TwigStackExtension.php
+++ b/src/TwigStackExtension.php
@@ -54,7 +54,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getTokenParsers()
+    public function getTokenParsers(): array
     {
         return [
             new StackTokenParser(),
@@ -66,7 +66,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getNodeVisitors()
+    public function getNodeVisitors(): array
     {
         return [
             new StackNodeVisitor(),
@@ -76,7 +76,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [];
     }
@@ -84,7 +84,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getTests()
+    public function getTests(): array
     {
         return [];
     }
@@ -92,7 +92,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [];
     }
@@ -100,7 +100,7 @@ final class TwigStackExtension implements ExtensionInterface
     /**
      * @inheritDoc
      */
-    public function getOperators()
+    public function getOperators(): array
     {
         return [];
     }


### PR DESCRIPTION
This PR eliminates many deprecation warnings like this one: 
`
Method "Twig\TokenParser\TokenParserInterface::parse()" might add "Node" as a native return type declaration in the future. Do the same in implementation "FilhoCodes\TwigStackExtension\TokenParsers\StackTokenParser" now to avoid errors or add an explicit @return annotation to suppress this message.
`